### PR TITLE
handle lines in /proc/cpuinfo that are longer than 512 bytes

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -396,7 +396,17 @@ int32_t xmem::query_sys_info() {
 	std::vector<uint32_t> phys_package_ids;
 	uint32_t id = 0;
 	while (!in.eof()) {
-		in.getline(line, 512, '\n'); 
+		in.getline(line, 512, '\n');
+
+		// the line with CPU feature flags may exceed 512 B, leaving the stream in an error state and the remainder of the line unread
+		if(in.fail() && in.gcount() == 511) {
+			// clean up the stream
+			in.clear();
+			// eat the remaining line
+			in.ignore(std::numeric_limits<std::streamsize>::max(),
+				'\n');
+		}
+
 		std::string line_string(line);
 		if (line_string.find("physical id") != std::string::npos) {
 			sscanf(line, "physical id\t\t\t: %u", &id);
@@ -441,7 +451,17 @@ int32_t xmem::query_sys_info() {
 	std::vector<uint32_t> core_ids;
 	in.open("/proc/cpuinfo");
 	while (!in.eof()) {
-		in.getline(line, 512, '\n'); 
+		in.getline(line, 512, '\n');
+		
+		// the line with CPU feature flags may exceed 512 B, leaving the stream in an error state and the remainder of the line unread
+		if(in.fail() && in.gcount() == 511) {
+			// clean up the stream
+			in.clear();
+			// eat the remaining line
+			in.ignore(std::numeric_limits<std::streamsize>::max(),
+				'\n');
+		}
+
 		std::string line_string(line);
 		if (line_string.find("core id") != std::string::npos) {
 			sscanf(line, "core id\t\t\t: %u", &id);


### PR DESCRIPTION
When parsing /proc/cpuinfo to determine the number of NUMA packages and CPU cores in Linux, xmem may hit lines with CPU flags exceeding 512 bytes in length (e.g., on Haswell-EP), causing xmem to enter an infinite loop. After the call to in.getline(), the ifstream in remains in a fail() state and all subsequent calls will return immediately. As a result, in.eof() will never be reached and the loop will never terminate.

Added code to detect that case, reset the iostream's fail() flag, and ignore the remaining line.

System: Ubuntu server 14.10 on an Intel Xeon E5-2630 v3 (Haswell-EP).
